### PR TITLE
[FEAT] 채용공고 상세 페이지

### DIFF
--- a/src/main/java/com/wanted/pre/onboarding/backend/controller/recruitment/RecruitmentController.java
+++ b/src/main/java/com/wanted/pre/onboarding/backend/controller/recruitment/RecruitmentController.java
@@ -1,4 +1,4 @@
-package com.wanted.pre.onboarding.backend.controller;
+package com.wanted.pre.onboarding.backend.controller.recruitment;
 
 import java.util.List;
 

--- a/src/main/java/com/wanted/pre/onboarding/backend/controller/recruitment/RecruitmentController.java
+++ b/src/main/java/com/wanted/pre/onboarding/backend/controller/recruitment/RecruitmentController.java
@@ -59,4 +59,10 @@ public class RecruitmentController {
 	public List<RecruitmentResponse> searchRecruitments(@RequestParam String keyword) {
 		return recruitmentService.findRecruitmentListByKeyword(keyword);
 	}
+
+	@GetMapping("/v1/recruitments/{id}")
+	public ResponseEntity<CommonResponse> getRecruitmentDetail(@PathVariable("id") Long id) {
+		CommonResponse response = new CommonResponse(HttpStatus.OK, recruitmentService.findRecruitmentDetail(id));
+		return new ResponseEntity<>(response, response.getCode());
+	}
 }

--- a/src/main/java/com/wanted/pre/onboarding/backend/controller/recruitment/RecruitmentController.java
+++ b/src/main/java/com/wanted/pre/onboarding/backend/controller/recruitment/RecruitmentController.java
@@ -56,8 +56,9 @@ public class RecruitmentController {
 	}
 
 	@GetMapping("/v1/recruitments/search")
-	public List<RecruitmentResponse> searchRecruitments(@RequestParam String keyword) {
-		return recruitmentService.findRecruitmentListByKeyword(keyword);
+	public ResponseEntity<CommonResponse> searchRecruitments(@RequestParam String keyword) {
+		CommonResponse response = new CommonResponse(HttpStatus.OK, recruitmentService.findRecruitmentListByKeyword(keyword));
+		return new ResponseEntity<>(response, response.getCode());
 	}
 
 	@GetMapping("/v1/recruitments/{id}")

--- a/src/main/java/com/wanted/pre/onboarding/backend/dto/recruitment/RecruitmentDetailResponse.java
+++ b/src/main/java/com/wanted/pre/onboarding/backend/dto/recruitment/RecruitmentDetailResponse.java
@@ -1,0 +1,35 @@
+package com.wanted.pre.onboarding.backend.dto.recruitment;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.wanted.pre.onboarding.backend.entity.recruitment.Recruitment;
+
+import lombok.Getter;
+
+@Getter
+public class RecruitmentDetailResponse {
+	private Long recruitmentId;
+	private String companyName;
+	private String country;
+	private String city;
+	private String position;
+	private int compensation;
+	private String skill;
+	private String content;
+	private List<Long> otherRecruitmentsIds = new ArrayList<>();
+
+	public RecruitmentDetailResponse(Recruitment recruitment) {
+		this.recruitmentId = recruitment.getId();
+		this.companyName = recruitment.getCompany().getName();
+		this.country = recruitment.getCompany().getCountry();
+		this.city = recruitment.getCompany().getCity();
+		this.position = recruitment.getPosition();
+		this.compensation = recruitment.getCompensation();
+		this.skill = recruitment.getSkill();
+		this.content = recruitment.getContent();
+		for (Recruitment r : recruitment.getCompany().getRecruitments()) {
+			otherRecruitmentsIds.add(r.getId());
+		}
+	}
+}

--- a/src/main/java/com/wanted/pre/onboarding/backend/service/recruitment/RecruitmentService.java
+++ b/src/main/java/com/wanted/pre/onboarding/backend/service/recruitment/RecruitmentService.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.wanted.pre.onboarding.backend.dto.recruitment.RecruitmentDetailResponse;
 import com.wanted.pre.onboarding.backend.dto.recruitment.RecruitmentRequest;
 import com.wanted.pre.onboarding.backend.dto.recruitment.RecruitmentResponse;
 import com.wanted.pre.onboarding.backend.dto.recruitment.RecruitmentUpdate;
@@ -61,5 +62,11 @@ public class RecruitmentService {
 
 	public List<RecruitmentResponse> findRecruitmentListByKeyword(String keyword) {
 		return recruitmentRepository.findRecruitmentsByKeyword(keyword);
+	}
+
+	public RecruitmentDetailResponse findRecruitmentDetail(Long id) {
+		Recruitment recruitment = recruitmentRepository.findById(id)
+			.orElseThrow(() -> new IllegalArgumentException("해당 채용공고는 존재하지 않습니다."));
+		return new RecruitmentDetailResponse(recruitment);
 	}
 }


### PR DESCRIPTION
### 👉 Issue
closed #6 

### 📌 Description
* RecruitmentDetailResponse에 `content, otherRecruitmentsIds` 필드 추가
* 채용공고 `id`를 `PathVariable`로 받아서 해당하는 채용공고 상세 페이지 반환

