### PR TITLE
[REFACTOR] 예외 테스트 클래스 domain별 분리

### DIFF
--- a/src/test/java/com/wanted/pre/onboarding/backend/service/application/ApplicationServiceExceptionTest.java
+++ b/src/test/java/com/wanted/pre/onboarding/backend/service/application/ApplicationServiceExceptionTest.java
@@ -1,0 +1,100 @@
+package com.wanted.pre.onboarding.backend.service.application;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.wanted.pre.onboarding.backend.dto.application.ApplicationRequest;
+import com.wanted.pre.onboarding.backend.entity.recruitment.Recruitment;
+import com.wanted.pre.onboarding.backend.entity.user.User;
+import com.wanted.pre.onboarding.backend.repository.application.ApplicationRepository;
+import com.wanted.pre.onboarding.backend.repository.recruitment.RecruitmentRepository;
+import com.wanted.pre.onboarding.backend.repository.user.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class ApplicationServiceExceptionTest {
+
+	@Mock
+	private ApplicationRepository applicationRepository;
+
+	@Mock
+	private UserRepository userRepository;
+
+	@Mock
+	private RecruitmentRepository recruitmentRepository;
+
+	@InjectMocks
+	private ApplicationService applicationService;
+
+	@Test
+	@DisplayName("존재하지 않는 사용자가 채용공고에 지원하면 예외가 발생한다.")
+	void saveApplicationWithNonExistenceUser() {
+		// Given
+		Long nonExistenceId = 1L;
+		ApplicationRequest request = new ApplicationRequest(nonExistenceId, 1L);
+
+		when(userRepository.findById(request.getUserId())).thenReturn(Optional.empty());
+		// When & Then
+		assertThatThrownBy(() -> applicationService.saveApplication(request))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("사용자가 존재하지 않습니다.");
+
+		verify(userRepository).findById(request.getUserId());
+		verify(recruitmentRepository, never()).findById(anyLong());
+		verify(applicationRepository, never()).existsByUserAndRecruitment(any(), any());
+		verify(applicationRepository, never()).save(any());
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 채용공고에 지원하면 예외가 발생한다.")
+	void saveApplicationWithNonExistenceRecruitment() {
+		// Given
+		User user = new User(1L);
+		Long nonExistenceRecruitmentId = 1L;
+		ApplicationRequest request = new ApplicationRequest(user.getId(), nonExistenceRecruitmentId);
+
+		when(userRepository.findById(request.getUserId())).thenReturn(Optional.of(user));
+		when(recruitmentRepository.findById(request.getRecruitmentId())).thenReturn(Optional.empty());
+
+		// When & Then
+		assertThatThrownBy(() -> applicationService.saveApplication(request))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("해당 채용공고는 존재하지 않습니다.");
+
+		verify(userRepository).findById(request.getUserId());
+		verify(recruitmentRepository).findById(request.getRecruitmentId());
+		verify(applicationRepository, never()).existsByUserAndRecruitment(any(), any());
+		verify(applicationRepository, never()).save(any());
+	}
+
+	@Test
+	@DisplayName("이미 지원한 채용공고에 지원하면 예외가 발생한다.")
+	void saveDuplicatedApplication() {
+		// Given
+		User user = new User(1L);
+		Recruitment recruitment = new Recruitment(1L, "백엔드 주니어 개발자", 1000, "자프링 개발자 모집합니다.", "Java");
+		ApplicationRequest request = new ApplicationRequest(user.getId(), recruitment.getId());
+
+		when(userRepository.findById(request.getUserId())).thenReturn(Optional.of(user));
+		when(recruitmentRepository.findById(request.getRecruitmentId())).thenReturn(Optional.of(recruitment));
+		when(applicationRepository.existsByUserAndRecruitment(user, recruitment)).thenReturn(true);
+
+		// When & Then
+		assertThatThrownBy(() -> applicationService.saveApplication(request))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("이미 지원한 공고입니다.");
+
+		verify(userRepository).findById(request.getUserId());
+		verify(recruitmentRepository).findById(request.getRecruitmentId());
+		verify(applicationRepository).existsByUserAndRecruitment(user, recruitment);
+		verify(applicationRepository, never()).save(any());
+	}
+}

--- a/src/test/java/com/wanted/pre/onboarding/backend/service/recruitment/RecruitmentServiceExceptionTest.java
+++ b/src/test/java/com/wanted/pre/onboarding/backend/service/recruitment/RecruitmentServiceExceptionTest.java
@@ -1,0 +1,73 @@
+package com.wanted.pre.onboarding.backend.service.recruitment;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.wanted.pre.onboarding.backend.dto.recruitment.RecruitmentRequest;
+import com.wanted.pre.onboarding.backend.dto.recruitment.RecruitmentUpdate;
+import com.wanted.pre.onboarding.backend.entity.company.Company;
+import com.wanted.pre.onboarding.backend.entity.recruitment.Recruitment;
+import com.wanted.pre.onboarding.backend.repository.company.CompanyRepository;
+import com.wanted.pre.onboarding.backend.repository.recruitment.RecruitmentRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class RecruitmentServiceExceptionTest {
+
+	@Mock
+	private CompanyRepository companyRepository;
+
+	@Mock
+	private RecruitmentRepository recruitmentRepository;
+
+	@InjectMocks
+	private RecruitmentService recruitmentService;
+
+	@Test
+	@DisplayName("존재하지 않는 회사가 채용공고를 작성하면 예외가 발생한다.")
+	void saveRecruitmentWithNonExistentCompany() {
+		// Given
+		Long nonExistentCompanyId = 1L;
+		RecruitmentRequest request = new RecruitmentRequest(nonExistentCompanyId, "백엔드 주니어 개발자", 1000, "자프링 개발자 모집합니다.", "Java");
+
+		when(companyRepository.findById(nonExistentCompanyId)).thenReturn(Optional.empty());
+
+		// When & Than
+		assertThatThrownBy(() -> recruitmentService.saveRecruitment(request))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("회사가 존재하지 않습니다.");
+
+		verify(companyRepository).findById(nonExistentCompanyId);
+		verify(recruitmentRepository, never()).save(any(Recruitment.class));
+	}
+
+
+	@Test
+	@DisplayName("존재하지 않는 채용공고를 수정하면 예외가 발생한다.")
+	void updateRecruitmentWithNonExistentRecruitment() {
+		// Given
+		Company company = new Company();
+		Long nonExistentRecruitmentId = 1L;
+		RecruitmentUpdate update = new RecruitmentUpdate("백엔드 시니어 개발자", 3000000, "10년 이상 백엔드 개발자 모집합니다.", "Java");
+
+		when(companyRepository.findById(company.getId())).thenReturn(Optional.of(company));
+		when(recruitmentRepository.findById(nonExistentRecruitmentId)).thenReturn(Optional.empty());
+
+		// When & Than
+		assertThatThrownBy(() -> recruitmentService.updateRecruitment(company.getId(), nonExistentRecruitmentId, update))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("해당 채용공고는 존재하지 않습니다.");
+
+		verify(companyRepository).findById(company.getId());
+		verify(recruitmentRepository).findById(nonExistentRecruitmentId);
+		verify(recruitmentRepository, never()).save(any(Recruitment.class));
+	}
+}

--- a/src/test/java/com/wanted/pre/onboarding/backend/service/recruitment/RecruitmentServiceExceptionTest.java
+++ b/src/test/java/com/wanted/pre/onboarding/backend/service/recruitment/RecruitmentServiceExceptionTest.java
@@ -3,6 +3,7 @@ package com.wanted.pre.onboarding.backend.service.recruitment;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.util.Collections;
 import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
@@ -10,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.wanted.pre.onboarding.backend.dto.recruitment.RecruitmentRequest;
@@ -27,6 +29,12 @@ public class RecruitmentServiceExceptionTest {
 
 	@Mock
 	private RecruitmentRepository recruitmentRepository;
+
+	@Spy
+	private Company nonRelatedCompany = new Company(3L, "비관련 회사", "한국", "부산");
+
+	@Spy
+	private Recruitment recruitment = new Recruitment(1L, "백엔드 주니어 개발자", 1000, "자프링 개발자 모집합니다.", "Java");
 
 	@InjectMocks
 	private RecruitmentService recruitmentService;
@@ -68,6 +76,26 @@ public class RecruitmentServiceExceptionTest {
 
 		verify(companyRepository).findById(company.getId());
 		verify(recruitmentRepository).findById(nonExistentRecruitmentId);
-		verify(recruitmentRepository, never()).save(any(Recruitment.class));
+	}
+
+	@Test
+	@DisplayName("해당 회사가 작성하지 않은 채용공고를 수정하면 예외가 발생한다.")
+	void updateRecruitmentWithNonRelatedCompany() {
+		// Given
+		recruitment.setCompany(new Company(2L, "원티드", "한국", "서울"));
+		RecruitmentUpdate update = new RecruitmentUpdate("백엔드 시니어 개발자", 3000000, "10년 이상 백엔드 개발자 모집합니다.", "Java");
+
+		when(companyRepository.findById(nonRelatedCompany.getId())).thenReturn(Optional.of(nonRelatedCompany));
+		when(recruitmentRepository.findById(recruitment.getId())).thenReturn(Optional.of(recruitment));
+		when(nonRelatedCompany.getRecruitments()).thenReturn(Collections.emptyList());
+
+		// When & Then
+		assertThatThrownBy(() -> recruitmentService.updateRecruitment(nonRelatedCompany.getId(), recruitment.getId(), update))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("귀사가 작성하지 않은 채용공고는 수정할 수 없습니다.");
+
+		verify(companyRepository).findById(nonRelatedCompany.getId());
+		verify(recruitmentRepository).findById(recruitment.getId());
+		verify(recruitment, never()).updateRecruitment(any(RecruitmentUpdate.class));
 	}
 }

--- a/src/test/java/com/wanted/pre/onboarding/backend/service/recruitment/RecruitmentServiceTest.java
+++ b/src/test/java/com/wanted/pre/onboarding/backend/service/recruitment/RecruitmentServiceTest.java
@@ -1,6 +1,5 @@
 package com.wanted.pre.onboarding.backend.service.recruitment;
 
-import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -62,24 +61,6 @@ class RecruitmentServiceTest {
 	}
 
 	@Test
-	@DisplayName("존재하지 않는 회사가 채용공고를 작성하면 예외가 발생한다.")
-	void saveRecruitmentWithNonExistentCompany() {
-		// Given
-		Long nonExistentCompanyId = 2L;
-		RecruitmentRequest request = new RecruitmentRequest(nonExistentCompanyId, "백엔드 주니어 개발자", 1000, "자프링 개발자 모집합니다.", "Java");
-
-		when(companyRepository.findById(nonExistentCompanyId)).thenReturn(Optional.empty());
-
-		// When & Than
-		assertThatThrownBy(() -> recruitmentService.saveRecruitment(request))
-			.isInstanceOf(IllegalArgumentException.class)
-			.hasMessage("회사가 존재하지 않습니다.");
-
-		verify(companyRepository).findById(nonExistentCompanyId);
-		verify(recruitmentRepository, never()).save(any(Recruitment.class));
-	}
-
-	@Test
 	@DisplayName("채용공고를 수정하면 정상적으로 수정된다.")
 	void updateRecruitment() {
 		// Given
@@ -99,22 +80,6 @@ class RecruitmentServiceTest {
 		assertEquals("백엔드 시니어 개발자", targetRecruitment.getPosition());
 		assertEquals(3000000, targetRecruitment.getCompensation());
 		assertEquals("10년 이상 백엔드 개발자 모집합니다.", targetRecruitment.getContent());
-	}
-
-	@Test
-	@DisplayName("존재하지 않는 채용공고를 수정하면 예외가 발생한다.")
-	void updateRecruitmentWithNonExistentRecruitment() {
-		// Given
-		Long nonExistentRecruitmentId = 2L;
-		RecruitmentUpdate update = new RecruitmentUpdate("백엔드 시니어 개발자", 3000000, "10년 이상 백엔드 개발자 모집합니다.", "Java");
-
-		when(companyRepository.findById(company.getId())).thenReturn(Optional.of(company));
-		when(recruitmentRepository.findById(nonExistentRecruitmentId)).thenReturn(Optional.empty());
-
-		// When & Than
-		assertThatThrownBy(() -> recruitmentService.updateRecruitment(company.getId(), nonExistentRecruitmentId, update))
-			.isInstanceOf(IllegalArgumentException.class)
-			.hasMessage("해당 채용공고는 존재하지 않습니다.");
 	}
 
 	@Test


### PR DESCRIPTION
### 👉 Issue
closed #12 
### 📌 Description
* 예외 처리 테스트까지 정상 테스트 클래스에서 수행하니 코드가 너무 길어진다. 
👉 예외 처리 테스트 클래스를 하나로 만들까 고민
👉 하나의 클래스에 모든 domain 테스트를 위한 mock 객체가 너무 많아진다.
👉 `domain`별로 예외 테스트 분리
* `RecruitmentServiceExceptionTest, ApplicationServiceExceptionTest` 생성하여 각각 예외 처리 테스트
* `RecruitmentServiceExceptionTest` 의 3가지 예외는 수정 API만 작성(삭제 API와 같은 로직이기 때문)
```java
@Test
@DisplayName("해당 회사가 작성하지 않은 채용공고를 수정하면 예외가 발생한다.")
void updateRecruitmentWithNonRelatedCompany() {
// Given
recruitment.setCompany(new Company(2L, "원티드", "한국", "서울"));
RecruitmentUpdate update = new RecruitmentUpdate("백엔드 시니어 개발자", 3000000, "10년 이상 백엔드 개발자 모집합니다.", "Java");

when(companyRepository.findById(nonRelatedCompany.getId())).thenReturn(Optional.of(nonRelatedCompany));
when(recruitmentRepository.findById(recruitment.getId())).thenReturn(Optional.of(recruitment));
when(nonRelatedCompany.getRecruitments()).thenReturn(Collections.emptyList());

// When & Then
assertThatThrownBy(() -> recruitmentService.updateRecruitment(nonRelatedCompany.getId(), recruitment.getId(), update))
	.isInstanceOf(IllegalArgumentException.class)
	.hasMessage("귀사가 작성하지 않은 채용공고는 수정할 수 없습니다.");

verify(companyRepository).findById(nonRelatedCompany.getId());
verify(recruitmentRepository).findById(recruitment.getId());
verify(recruitment, never()).updateRecruitment(any(RecruitmentUpdate.class));
}
````
* 이 때, `nonRelatedCompany`객체와 `recruitment`객체는 `@Spy` 로 만들어서 메소드 실행 확인 